### PR TITLE
Fix indexer doing wrong URLs for autocomplete

### DIFF
--- a/Extras/indexer/indexer.js
+++ b/Extras/indexer/indexer.js
@@ -122,7 +122,7 @@ const oldIndex = require("../../index.json");
       return {
         file: acFile,
         url:
-          "https://raw.githubusercontent.com/OnixClient-Scripts/OnixClient_Scripts/master/AutoComplete/library" +
+          "https://raw.githubusercontent.com/OnixClient-Scripts/OnixClient_Scripts/master/AutoComplete/library/" +
           acFile,
         hash: acHash,
         lastUpdated: acLastUpdated,


### PR DESCRIPTION
Was missing a / between the base URL and the file name